### PR TITLE
ISSUE-16: Multiple prefixes + "what should match/segment" picker

### DIFF
--- a/config/schema/fragaria.schema.yml
+++ b/config/schema/fragaria.schema.yml
@@ -29,3 +29,62 @@ fragaria.datacite:
     processor_entity_id:
       type: string
       label: "Uuid of the Metadata Display used to Cast DataCite valid metadata"
+fragaria.fragariaredirect_entity.*:
+  type: config_entity
+  label: 'Fragaria Redirect Config Entity'
+  mapping:
+    uuid:
+    langcode: en
+    status: true
+    id:
+      type: string
+      label: 'ID'
+    label:
+      type: string
+      label: 'Label'
+    path_prefixes:
+      type: sequence
+      label: 'Path Prefixes'
+      sequence:
+        - type: string
+    search_api_index:
+      type: string
+      label: 'Search API Index'
+    search_api_field:
+      type: string
+      label: 'Saerch API Field'
+    path_suffixes:
+      type: sequence
+      label: 'Path Suffixes'
+      sequence:
+        - type: string
+    search_api_field_value_prefixes:
+      type: sequence
+      label: 'search api field value prefixes'
+      sequence:
+        - type: string
+    search_api_field_value_suffixes:
+      type: sequence
+      label: 'search api field value Suffixes'
+      sequence:
+        - type: string
+    variable_path_suffix:
+      type: boolean
+      label: 'Variable Path Suffix'
+    redirect_http_code:
+      type: string
+      label: 'Redirect HTTP Code'
+    cache:
+      type: boolean
+      label: 'Cached'
+    active:
+       type: boolean
+       label: 'Active'
+    do_replacement:
+      type: boolean
+      label: 'If do/UUID replacement is added'
+    segments_in_pattern:
+      type: sequence
+      label: 'Segments of the exposed URL to be sent against search API'
+      sequence:
+        - type: string

--- a/config/schema/fragaria.schema.yml
+++ b/config/schema/fragaria.schema.yml
@@ -94,3 +94,6 @@ fragaria.fragariaredirect_entity.*:
     custom_404:
       type: string
       label: 'A valid relative path for 404 responses. Leave empty for the default'
+    allow_empty_variable:
+      type: boolean
+      label: 'If the Route Path (without suffixes) allows to be called without the variable part'

--- a/config/schema/fragaria.schema.yml
+++ b/config/schema/fragaria.schema.yml
@@ -88,3 +88,6 @@ fragaria.fragariaredirect_entity.*:
       label: 'Segments of the exposed URL to be sent against search API'
       sequence:
         - type: string
+    custom_404:
+      type: string
+      label: 'A valid relative path for 404 responses. Leave empty for the default'

--- a/config/schema/fragaria.schema.yml
+++ b/config/schema/fragaria.schema.yml
@@ -34,8 +34,11 @@ fragaria.fragariaredirect_entity.*:
   label: 'Fragaria Redirect Config Entity'
   mapping:
     uuid:
-    langcode: en
-    status: true
+      type: string
+    langcode:
+      type: string
+    status:
+      type: boolean
     id:
       type: string
       label: 'ID'

--- a/fragaria.install
+++ b/fragaria.install
@@ -39,3 +39,40 @@ function fragaria_uninstall() {
   return t('Removing fragariaredirect_entity');
 }
 
+/**
+ * Implements hook_update_N().
+ *
+ * Updates Fragaria Redirect Config Entity to allow Multiple prefixes.
+ *
+ */
+function fragaria_update_10002() {
+    $message = "Nothing to update. Fragaria Entity is not installed.";
+    $entity_type = \Drupal::entityDefinitionUpdateManager()->getEntityType('fragariaredirect_entity');
+    if ($entity_type) {
+        $config_factory = \Drupal::configFactory();
+        foreach ($config_factory->listAll('fragaria.fragariaredirect_entity.') as $fragaria_config_name) {
+            $fragaria_config = $config_factory->getEditable($fragaria_config_name);
+            $prefix = $fragaria_config->get('path_prefix');
+            $prefixes = array_filter(array_map('trim', explode(PHP_EOL, $prefix)));
+            $fragaria_config->clear('path_prefix');
+            $fragaria_config->set('path_prefixes', $prefixes);
+            $fragaria_config->save(TRUE);
+        }
+
+        $entity_config_export = $entity_type->get('config_export');
+        $new_entity_config_export = [];
+        foreach($entity_config_export as $key) {
+            if ($key !== 'path_prefix') {
+                $new_entity_config_export[] = $key;
+            }
+            else {
+                $new_entity_config_export[] = 'path_prefixes';
+            }
+        }
+        $entity_config_export[]  = "segments_in_pattern";
+        $entity_type->set('config_export', $entity_config_export);
+        \Drupal::entityDefinitionUpdateManager()->updateEntityType($entity_type);
+        $message = "Fragaria Entity's Schema and Values updated to handle multiple prefixes and configurable segment matching.";
+    }
+    return $message;
+}

--- a/fragaria.install
+++ b/fragaria.install
@@ -70,6 +70,7 @@ function fragaria_update_10002() {
             }
         }
         $entity_config_export[]  = "segments_in_pattern";
+        $entity_config_export[]  = "custom_404";
         $entity_type->set('config_export', $entity_config_export);
         \Drupal::entityDefinitionUpdateManager()->updateEntityType($entity_type);
         $message = "Fragaria Entity's Schema and Values updated to handle multiple prefixes and configurable segment matching.";

--- a/fragaria.install
+++ b/fragaria.install
@@ -71,6 +71,7 @@ function fragaria_update_10002() {
         }
         $entity_config_export[]  = "segments_in_pattern";
         $entity_config_export[]  = "custom_404";
+         $entity_config_export[] = "allow_empty_variable";
         $entity_type->set('config_export', $entity_config_export);
         \Drupal::entityDefinitionUpdateManager()->updateEntityType($entity_type);
         $message = "Fragaria Entity's Schema and Values updated to handle multiple prefixes and configurable segment matching.";

--- a/src/Controller/Redirect.php
+++ b/src/Controller/Redirect.php
@@ -8,16 +8,20 @@
 
 namespace Drupal\fragaria\Controller;
 
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\AccessAwareRouterInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\fragaria\Entity\FragariaRedirectConfigEntity;
 use Drupal\search_api\ParseMode\ParseModePluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -80,7 +84,10 @@ class Redirect extends ControllerBase {
   public function redirect_processor(Request $request, $key) {
     $entity = $this->getFragariaEntityFromRouteMatch($this->routeMatch);
     if ($entity) {
-      $object = $this->searchAPIfindKey($key, $entity);
+      // Complete match without Domain. WE do not allow the domain to be used
+      // That can be simulated with a prefix.
+      $pathinfo = $this->routeMatch->getRouteObject()->getPath();
+      $object = $this->searchAPIfindKey($key, $pathinfo, $entity);
       if ($object) {
         $url = $object->toUrl('canonical', ['absolute' => FALSE])->toString();
         $response = new RedirectResponse($url, (int) $entity->getRedirectHttpCode());
@@ -143,19 +150,40 @@ class Redirect extends ControllerBase {
   }
 
   /**
-   * @param                                                      $key
+   * @param string $key
+   *    The variable part
+   * @param string $path
+   *    The complete path. will be /prefixes()/{key}/suffixes
    * @param \Drupal\fragaria\Entity\FragariaRedirectConfigEntity $entity
    *
    * @return mixed|null
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  private function searchAPIfindKey($key, FragariaRedirectConfigEntity $entity) {
+  private function searchAPIfindKey(string $key, string $path, FragariaRedirectConfigEntity $entity) {
 
     /** @var \Drupal\search_api\IndexInterface[] $indexes */
     $index = \Drupal::entityTypeManager()
       ->getStorage('search_api_index')
       ->load($entity->getSearchApiIndex());
+
+    $decomposed_path =  array_filter(explode("/", $path));
+    $decomposed_static_prefix = '/';
+    $decomposed_static_suffix = '/';
+    $found_key = false;
+    foreach ($decomposed_path as $segment) {
+        if ($found_key) {
+          $decomposed_static_suffix = $decomposed_static_suffix . $segment . '/';
+        }
+        else {
+          if ($segment == "{key}") {
+            $found_key = TRUE;
+          }
+          else {
+            $decomposed_static_prefix = $decomposed_static_prefix . $segment . '/';
+          }
+        }
+    }
 
     $value = NULL;
     if ($index) {
@@ -165,20 +193,33 @@ class Redirect extends ControllerBase {
         'search_api_retrieved_field_values',
         [$entity->getSearchApiField() => $entity->getSearchApiField()]
       );
-
-      $value_with_prefixes = [$key];
-      if ($entity->getSearchApiFieldValuePrefixes()) {
-        foreach ($entity->getSearchApiFieldValuePrefixes() as $prefix) {
-          $value_with_prefixes[] = $prefix.$key;
-        }
+      $segments_in_pattern = $entity->getSegmentsInPattern();
+      // Should never happen but people could insert a config entity manually
+      // via drush. If so we default to variable part
+      if (empty($segments_in_pattern)) {
+        $segments_in_pattern = ['variable'];
       }
-      if ($entity->getSearchApiFieldValueSuffixes()) {
-        foreach ($entity->getSearchApiFieldValueSuffixes() as $suffix) {
-          foreach ($value_with_prefixes as $prefixed) {
-            $value_with_prefixes[] = $prefixed.$suffix;
+      if (in_array('variable', $segments_in_pattern)) {
+        $value_with_prefixes = [$key];
+        if ($entity->getSearchApiFieldValuePrefixes()) {
+          foreach ($entity->getSearchApiFieldValuePrefixes() as $prefix) {
+            $value_with_prefixes[] = $prefix . $key;
+          }
+        }
+        if ($entity->getSearchApiFieldValueSuffixes()) {
+          foreach ($entity->getSearchApiFieldValueSuffixes() as $suffix) {
+            foreach ($value_with_prefixes as $prefixed) {
+              $value_with_prefixes[] = $prefixed . $suffix;
+            }
           }
         }
       }
+      // Now for the extra prefix part.
+      if (in_array('prefixes', $segments_in_pattern)) {
+        foreach ($value_with_prefixes as $prefixed) {
+        }
+      }
+
 
       if (count($value_with_prefixes) == 1) {
         $query->addCondition(
@@ -200,4 +241,37 @@ class Redirect extends ControllerBase {
   }
 
 
+  /**
+   * Makes a subrequest to retrieve the custom error page.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   *   The event to process.
+   * @param string $custom_path
+   *   The custom path to which to make a subrequest for this error message.
+   * @param int $status_code
+   *   The status code for the error being handled.
+   */
+  protected function makeSubrequestToCustom404(ExceptionEvent $event, $custom_path) {
+    $url = Url::fromUserInput($custom_path);
+    if ($url->isRouted()) {
+      $access_result = $this->accessManager->checkNamedRoute($url->getRouteName(), $url->getRouteParameters(), NULL, TRUE);
+      $request = $event->getRequest();
+      if (!$request->attributes->has(AccessAwareRouterInterface::ACCESS_RESULT)) {
+        $request->attributes->set(AccessAwareRouterInterface::ACCESS_RESULT, $access_result);
+      }
+      else {
+        $existing_access_result = $request->attributes->get(AccessAwareRouterInterface::ACCESS_RESULT);
+        if ($existing_access_result instanceof RefinableCacheableDependencyInterface) {
+          $existing_access_result->addCacheableDependency($access_result);
+        }
+      }
+
+      // Only perform the subrequest if the custom path is actually accessible.
+      if (!$access_result->isAllowed()) {
+        return;
+      }
+    }
+
+    $this->makeSubrequest($event, $custom_path, Response::HTTP_NOT_FOUND);
+  }
 }

--- a/src/Controller/Redirect.php
+++ b/src/Controller/Redirect.php
@@ -8,13 +8,17 @@
 
 namespace Drupal\fragaria\Controller;
 
+use Drupal\Core\Access\AccessManagerInterface;
+use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\AccessAwareRouterInterface;
+use Drupal\Core\Routing\RedirectDestinationInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\fragaria\Entity\FragariaRedirectConfigEntity;
 use Drupal\search_api\ParseMode\ParseModePluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -22,7 +26,11 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Drupal\Core\Url;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 /**
  * Class Redirect.
@@ -51,16 +59,42 @@ class Redirect extends ControllerBase {
   protected $parseModeManager;
 
   /**
+   * The access manager.
+   *
+   * @var \Drupal\Core\Access\AccessManagerInterface
+   */
+  protected AccessManagerInterface $accessManager;
+
+  /**
+   * @var \Symfony\Component\Routing\Matcher\UrlMatcherInterface
+   */
+  private UrlMatcherInterface $accessUnawareRouter;
+
+  /**
+   * The redirect destination service.
+   *
+   * @var \Drupal\Core\Routing\RedirectDestinationInterface
+   */
+  protected $redirectDestination;
+
+
+  /**
    * Constructs a new WebhookController object.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entitytype_manager,
-    ParseModePluginManager $parse_mode_manager, RouteMatchInterface $route_match) {
+  public function __construct(ConfigFactoryInterface $config_factory,
+    EntityTypeManagerInterface $entitytype_manager,
+    ParseModePluginManager $parse_mode_manager,
+    RouteMatchInterface $route_match,
+    AccessManagerInterface $access_manager,
+    RedirectDestinationInterface $redirect_destination,
+    UrlMatcherInterface $access_unaware_router) {
     $this->configFactory = $config_factory;
     $this->entityTypeManager = $entitytype_manager;
     $this->parseModeManager = $parse_mode_manager;
     $this->routeMatch = $route_match;
-
-
+    $this->accessManager = $access_manager;
+    $this->redirectDestination = $redirect_destination;
+    $this->accessUnawareRouter = $access_unaware_router;
   }
 
   /**
@@ -72,6 +106,9 @@ class Redirect extends ControllerBase {
       $container->get('entity_type.manager'),
       $container->get('plugin.manager.search_api.parse_mode'),
       $container->get('current_route_match'),
+      $container->get('access_manager'),
+      $container->get('redirect.destination'),
+      $container->get('router.no_access_checks')
     );
   }
 
@@ -242,16 +279,14 @@ class Redirect extends ControllerBase {
 
 
   /**
-   * Makes a subrequest to retrieve the custom error page.
+   * Makes a sub request to retrieve a custom error page.
    *
    * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
    *   The event to process.
    * @param string $custom_path
-   *   The custom path to which to make a subrequest for this error message.
-   * @param int $status_code
-   *   The status code for the error being handled.
+   *   The custom path to which to make a sub request for this error message.
    */
-  protected function makeSubrequestToCustom404(ExceptionEvent $event, $custom_path) {
+  protected function makeSubrequestToCustom404(ExceptionEvent $event, string $custom_path): void {
     $url = Url::fromUserInput($custom_path);
     if ($url->isRouted()) {
       $access_result = $this->accessManager->checkNamedRoute($url->getRouteName(), $url->getRouteParameters(), NULL, TRUE);
@@ -272,6 +307,64 @@ class Redirect extends ControllerBase {
       }
     }
 
-    $this->makeSubrequest($event, $custom_path, Response::HTTP_NOT_FOUND);
+    $request = $event->getRequest();
+    $exception = $event->getThrowable();
+
+    try {
+      // Reuse the exact same request (so keep the same URL, keep the access
+      // result, the exception, et cetera) but override the routing information.
+      // This means that aside from routing, this is identical to the master
+      // request. This allows us to generate a response that is executed on
+      // behalf of the master request, i.e. for the original URL. This is what
+      // allows us to e.g. generate a 404 response for the original URL; if we
+      // would execute a subrequest with the 404 route's URL, then it'd be
+      // generated for *that* URL, not the *original* URL.
+      $sub_request = clone $request;
+
+      // The routing to the 404 page should be done as GET request because it is
+      // restricted to GET and POST requests only. Otherwise, a DELETE request
+      // would for example trigger a method not allowed exception.
+      $request_context = clone ($this->accessUnawareRouter->getContext());
+      $request_context->setMethod('GET');
+      $this->accessUnawareRouter->setContext($request_context);
+
+      $sub_request->attributes->add($this->accessUnawareRouter->match($url));
+
+      // Add to query (GET) or request (POST) parameters:
+      // - 'destination' (to ensure e.g. the login form in a 403 response
+      //   redirects to the original URL)
+      // - '_exception_statuscode'
+      $parameters = $sub_request->isMethod('GET') ? $sub_request->query : $sub_request->request;
+      $parameters->add($this->redirectDestination->getAsArray() + ['_exception_statuscode' => Response::HTTP_NOT_FOUND]);
+
+      $response = $this->httpKernel->handle($sub_request, HttpKernelInterface::SUB_REQUEST);
+      // Only 2xx responses should have their status code overridden; any
+      // other status code should be passed on: redirects (3xx), error (5xx)…
+      // @see https://www.drupal.org/node/2603788#comment-10504916
+      if ($response->isSuccessful()) {
+        $response->setStatusCode(Response::HTTP_NOT_FOUND);
+      }
+
+      // Persist the exception's cacheability metadata, if any. If the exception
+      // itself isn't cacheable, then this will make the response uncacheable:
+      // max-age=0 will be set.
+      if ($response instanceof CacheableResponseInterface) {
+        $response->addCacheableDependency($exception);
+      }
+
+      // Persist any special HTTP headers that were set on the exception.
+      if ($exception instanceof HttpExceptionInterface) {
+        $response->headers->add($exception->getHeaders());
+      }
+
+      $event->setResponse($response);
+    }
+    catch (\Exception $e) {
+      // If an error happened in the subrequest we can't do much else. Instead,
+      // just log it. The DefaultExceptionSubscriber will catch the original
+      // exception and handle it normally.
+      $error = Error::decodeException($e);
+      $this->getLogger('fragaria')->log($error['severity_level'], Error::DEFAULT_ERROR_MESSAGE, $error);
+    }
   }
 }

--- a/src/Controller/Redirect.php
+++ b/src/Controller/Redirect.php
@@ -264,6 +264,10 @@ class Redirect extends ControllerBase {
       }
       if (in_array('variable', $segments_in_pattern)) {
         $value_with_prefixes[0] = isset($value_with_prefixes[0]) ? $value_with_prefixes[0] = $value_with_prefixes[0].$key : [$key];
+        // We are parsing the variable part but it is empty, remove the last "/"
+        if ($key == "") {
+          $value_with_prefixes[0] = rtrim($value_with_prefixes[0],"/");
+        }
       }
       if (in_array('suffixes', $segments_in_pattern)) {
         $value_with_prefixes[0] = isset($value_with_prefixes[0]) ? $value_with_prefixes[0] = $value_with_prefixes[0]. $decomposed_static_suffix : [$decomposed_static_suffix];

--- a/src/Controller/Redirect.php
+++ b/src/Controller/Redirect.php
@@ -77,9 +77,17 @@ class Redirect extends ControllerBase {
    */
   protected $redirectDestination;
 
+  /**
+   * The HTTP kernel.
+   *
+   * @var \Symfony\Component\HttpKernel\HttpKernelInterface
+   */
+  protected $httpKernel;
+
+
 
   /**
-   * Constructs a new WebhookController object.
+   * Constructs the redirect Controller object.
    */
   public function __construct(ConfigFactoryInterface $config_factory,
     EntityTypeManagerInterface $entitytype_manager,
@@ -87,7 +95,8 @@ class Redirect extends ControllerBase {
     RouteMatchInterface $route_match,
     AccessManagerInterface $access_manager,
     RedirectDestinationInterface $redirect_destination,
-    UrlMatcherInterface $access_unaware_router) {
+    UrlMatcherInterface $access_unaware_router,
+    HttpKernelInterface $http_kernel) {
     $this->configFactory = $config_factory;
     $this->entityTypeManager = $entitytype_manager;
     $this->parseModeManager = $parse_mode_manager;
@@ -95,6 +104,7 @@ class Redirect extends ControllerBase {
     $this->accessManager = $access_manager;
     $this->redirectDestination = $redirect_destination;
     $this->accessUnawareRouter = $access_unaware_router;
+    $this->httpKernel = $http_kernel;
   }
 
   /**
@@ -108,7 +118,8 @@ class Redirect extends ControllerBase {
       $container->get('current_route_match'),
       $container->get('access_manager'),
       $container->get('redirect.destination'),
-      $container->get('router.no_access_checks')
+      $container->get('router.no_access_checks'),
+      $container->get('http_kernel')
     );
   }
 
@@ -131,7 +142,12 @@ class Redirect extends ControllerBase {
         return $response;
       }
       else {
-        throw new NotFoundHttpException();
+        if ($url404 = $entity->getCustom404()) {
+          return $this->makeSubrequestToCustom404($request, $url404);
+        }
+        else {
+          throw new NotFoundHttpException();
+        }
       }
     }
     else {
@@ -204,25 +220,8 @@ class Redirect extends ControllerBase {
       ->getStorage('search_api_index')
       ->load($entity->getSearchApiIndex());
 
-    $decomposed_path =  array_filter(explode("/", $path));
-    $decomposed_static_prefix = '/';
-    $decomposed_static_suffix = '/';
-    $found_key = false;
-    foreach ($decomposed_path as $segment) {
-        if ($found_key) {
-          $decomposed_static_suffix = $decomposed_static_suffix . $segment . '/';
-        }
-        else {
-          if ($segment == "{key}") {
-            $found_key = TRUE;
-          }
-          else {
-            $decomposed_static_prefix = $decomposed_static_prefix . $segment . '/';
-          }
-        }
-    }
-
     $value = NULL;
+    $value_with_prefixes = [];
     if ($index) {
       $query = $index->query();
       $query->range(0, 1);
@@ -236,24 +235,53 @@ class Redirect extends ControllerBase {
       if (empty($segments_in_pattern)) {
         $segments_in_pattern = ['variable'];
       }
-      if (in_array('variable', $segments_in_pattern)) {
-        $value_with_prefixes = [$key];
-        if ($entity->getSearchApiFieldValuePrefixes()) {
-          foreach ($entity->getSearchApiFieldValuePrefixes() as $prefix) {
-            $value_with_prefixes[] = $prefix . $key;
+
+      // Now for the extra prefix part.
+      if (in_array('suffixes', $segments_in_pattern) || in_array('prefixes', $segments_in_pattern)) {
+        $decomposed_path =  array_filter(explode("/", $path));
+        $decomposed_static_prefix = '';
+        $decomposed_static_suffix = '';
+        $found_key = false;
+        foreach ($decomposed_path as $segment) {
+          if ($found_key) {
+            $decomposed_static_suffix = $decomposed_static_suffix . $segment . '/';
           }
-        }
-        if ($entity->getSearchApiFieldValueSuffixes()) {
-          foreach ($entity->getSearchApiFieldValueSuffixes() as $suffix) {
-            foreach ($value_with_prefixes as $prefixed) {
-              $value_with_prefixes[] = $prefixed . $suffix;
+          else {
+            if ($segment == "{key}") {
+              $found_key = TRUE;
+            }
+            else {
+              $decomposed_static_prefix = $decomposed_static_prefix . $segment . '/';
             }
           }
         }
       }
-      // Now for the extra prefix part.
+      // A this stage we will have a single ONE
+      // Since prefixes and suffixes are coming from the actual URL
+      // And not the many settings.
       if (in_array('prefixes', $segments_in_pattern)) {
-        foreach ($value_with_prefixes as $prefixed) {
+        $value_with_prefixes[] = $decomposed_static_prefix ;
+      }
+      if (in_array('variable', $segments_in_pattern)) {
+        $value_with_prefixes[0] = isset($value_with_prefixes[0]) ? $value_with_prefixes[0] = $value_with_prefixes[0].$key : [$key];
+      }
+      if (in_array('suffixes', $segments_in_pattern)) {
+        $value_with_prefixes[0] = isset($value_with_prefixes[0]) ? $value_with_prefixes[0] = $value_with_prefixes[0]. $decomposed_static_suffix : [$decomposed_static_suffix];
+      }
+      // This will also hold the original pre-prefixed one
+      if ($entity->getSearchApiFieldValuePrefixes()) {
+        foreach ($entity->getSearchApiFieldValuePrefixes() as $prefix) {
+          foreach ($value_with_prefixes as $prefixed) {
+            $value_with_prefixes[] = $prefix . $prefixed;
+          }
+        }
+      }
+      // This will also hold the original + prefixed ones
+      if ($entity->getSearchApiFieldValueSuffixes()) {
+        foreach ($entity->getSearchApiFieldValueSuffixes() as $suffix) {
+          foreach ($value_with_prefixes as $prefixed) {
+            $value_with_prefixes[] = $prefixed . $suffix;
+          }
         }
       }
 
@@ -281,16 +309,15 @@ class Redirect extends ControllerBase {
   /**
    * Makes a sub request to retrieve a custom error page.
    *
-   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   * @param Request $request
    *   The event to process.
    * @param string $custom_path
    *   The custom path to which to make a sub request for this error message.
    */
-  protected function makeSubrequestToCustom404(ExceptionEvent $event, string $custom_path): void {
+  protected function makeSubrequestToCustom404(Request $request, string $custom_path) {
     $url = Url::fromUserInput($custom_path);
     if ($url->isRouted()) {
       $access_result = $this->accessManager->checkNamedRoute($url->getRouteName(), $url->getRouteParameters(), NULL, TRUE);
-      $request = $event->getRequest();
       if (!$request->attributes->has(AccessAwareRouterInterface::ACCESS_RESULT)) {
         $request->attributes->set(AccessAwareRouterInterface::ACCESS_RESULT, $access_result);
       }
@@ -306,9 +333,7 @@ class Redirect extends ControllerBase {
         return;
       }
     }
-
-    $request = $event->getRequest();
-    $exception = $event->getThrowable();
+    $exception = new NotFoundHttpException();
 
     try {
       // Reuse the exact same request (so keep the same URL, keep the access
@@ -328,7 +353,7 @@ class Redirect extends ControllerBase {
       $request_context->setMethod('GET');
       $this->accessUnawareRouter->setContext($request_context);
 
-      $sub_request->attributes->add($this->accessUnawareRouter->match($url));
+      $sub_request->attributes->add($this->accessUnawareRouter->match($url->toString()));
 
       // Add to query (GET) or request (POST) parameters:
       // - 'destination' (to ensure e.g. the login form in a 403 response
@@ -357,7 +382,7 @@ class Redirect extends ControllerBase {
         $response->headers->add($exception->getHeaders());
       }
 
-      $event->setResponse($response);
+      return $response;
     }
     catch (\Exception $e) {
       // If an error happened in the subrequest we can't do much else. Instead,
@@ -365,6 +390,7 @@ class Redirect extends ControllerBase {
       // exception and handle it normally.
       $error = Error::decodeException($e);
       $this->getLogger('fragaria')->log($error['severity_level'], Error::DEFAULT_ERROR_MESSAGE, $error);
+      throw $exception;
     }
   }
 }

--- a/src/Entity/Controller/FragariaRedirectConfigEntityListBuilder.php
+++ b/src/Entity/Controller/FragariaRedirectConfigEntityListBuilder.php
@@ -99,22 +99,33 @@ class FragariaRedirectConfigEntityListBuilder extends ConfigEntityListBuilder {
    */
   private function getDemoUrlForItem(FragariaRedirectConfigEntity $entity, string $value) {
     $url = NULL;
-    try {
-      $url = \Drupal::urlGenerator()
-        ->generateFromRoute(
-          'fragaria_redirect.' . $entity->id(),
-          [
-            'key' => $value,
-          ]
-        );
+    $prefixes = $entity->getPathPrefixes();
+    if (is_array($prefixes) && !empty($prefixes)) {
+      $prefix = reset($prefixes);
+      $name = 'fragaria_redirect.' . md5($prefix) .'-'. $entity->id();
+      try {
+        $url = \Drupal::urlGenerator()
+          ->generateFromRoute(
+            $name,
+            [
+              'key' => $value,
+            ]
+          );
+      }
+      catch (\Exception $e) {
+        $this->messenger()
+          ->addError('We could not generate an example URL for the Fragaria Redirect Entity @label', [
+            '@label' => $entity->label(),
+          ]);
+      }
+      return $url;
     }
-    catch (\Exception $e) {
-      $this->messenger()->addError('We could not generate an example URL for the Fragaria Redirect Entity @label',[
-        '@label' => $entity->label(),
-      ]);
+    else {
+      $this->messenger()
+        ->addError('We could not generate an example URL for the Fragaria Redirect Entity @label bc you have no prefixes. Please edit and correct.', [
+          '@label' => $entity->label(),
+        ]);
     }
-
-    return $url;
   }
 
   /**

--- a/src/Entity/FragariaRedirectConfigEntity.php
+++ b/src/Entity/FragariaRedirectConfigEntity.php
@@ -246,7 +246,8 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
    * @return string
    */
   public function getPathPrefixes(): array {
-    return $this->path_prefixes;
+    $prefixes = array_map(function($prefix) { if (is_string($prefix)) { return trim(trim($prefix), '/');} else {return NULL;}}, $this->path_prefixes);
+    return array_filter($prefixes);;
   }
 
   /**
@@ -276,6 +277,14 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
   public function setPathSuffixes(array $path_suffixes): void {
     $this->path_suffixes = $path_suffixes;
   }
+
+  /**
+   * @param array $path_prefixes
+   */
+  public function setPathPrefixes(array $path_prefixes): void {
+    $this->path_prefixes = $path_prefixes;
+  }
+
 
   /**
    * Checks if this Config is active.

--- a/src/Entity/FragariaRedirectConfigEntity.php
+++ b/src/Entity/FragariaRedirectConfigEntity.php
@@ -50,7 +50,8 @@ use Drupal\Core\DependencyInjection\DependencySerializationTrait;
  *     "redirect_http_code",
  *     "cache",
  *     "active",
- *     "do_replacement"
+ *     "do_replacement",
+ *     "custom_404",
  *   },
  *   links = {
  *     "edit-form" = "/admin/config/archipelago/fragariaredirect/{fragariaredirect_entity}/edit",
@@ -88,7 +89,7 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
   /**
    * What segments of the resolved URL to be used for the Search API pattern matching
    *
-   * @var string
+   * @var array
    */
   public array $segments_in_pattern = [];
 
@@ -150,6 +151,14 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
    * @var string
    */
   protected $redirect_http_code = '303';
+
+
+  /**
+   * The Type of HTTP redirect Code to use
+   *
+   * @var ?string
+   */
+  protected ?string $custom_404 = NULL;
 
   /**
    * If the Config Entity is active or not.
@@ -347,4 +356,9 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
   public function setSegmentsInPattern(array $segments_in_pattern): void {
     $this->segments_in_pattern = $segments_in_pattern;
   }
+
+  public function getCustom404(): ?string {
+    return $this->custom_404;
+  }
+
 }

--- a/src/Entity/FragariaRedirectConfigEntity.php
+++ b/src/Entity/FragariaRedirectConfigEntity.php
@@ -39,7 +39,8 @@ use Drupal\Core\DependencyInjection\DependencySerializationTrait;
  *     "id",
  *     "label",
  *     "uuid",
- *     "path_prefix",
+ *     "path_prefixes",
+ *     "segments_in_pattern",
  *     "search_api_index",
  *     "search_api_field",
  *     "path_suffixes",
@@ -68,7 +69,7 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
    * @var string
    */
 
-  protected $id;
+  protected string $id;
 
   /**
    * The human-readable name of the form or view mode.
@@ -78,11 +79,19 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
   protected string $label;
 
   /**
-   * Prefix this route will respond to
+   * Prefixes this route will respond to
+   *
+   * @var array
+   */
+  public array $path_prefixes = [];
+
+  /**
+   * What segments of the resolved URL to be used for the Search API pattern matching
    *
    * @var string
    */
-  public string $path_prefix;
+  public array $segments_in_pattern = [];
+
 
   /**
    * Additional Prefixes this route will respond to
@@ -227,8 +236,8 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
   /**
    * @return string
    */
-  public function getPathPrefix(): string {
-    return $this->path_prefix;
+  public function getPathPrefixes(): array {
+    return $this->path_prefixes;
   }
 
   /**
@@ -331,5 +340,11 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
     $this->do_replacement = $do_replacement;
   }
 
+  public function getSegmentsInPattern(): array {
+    return $this->segments_in_pattern;
+  }
 
+  public function setSegmentsInPattern(array $segments_in_pattern): void {
+    $this->segments_in_pattern = $segments_in_pattern;
+  }
 }

--- a/src/Entity/FragariaRedirectConfigEntity.php
+++ b/src/Entity/FragariaRedirectConfigEntity.php
@@ -294,7 +294,6 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
     $this->path_prefixes = $path_prefixes;
   }
 
-
   /**
    * Checks if this Config is active.
    *
@@ -387,4 +386,16 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
     $this->allow_empty_variable = $allow_empty_variable;
   }
 
+  public function isSafeRouteString(string $routeAsString):bool {
+      $matches = [];
+      // We are allowing Slashes here but no dots
+      $matched = preg_match('/[^a-zA-Z0-9\/\-_~]/m', $routeAsString, $matches);
+      if ($matched === 0) {
+          return TRUE;
+      }
+      else {
+          return FALSE;
+      }
+  }
+  
 }

--- a/src/Entity/FragariaRedirectConfigEntity.php
+++ b/src/Entity/FragariaRedirectConfigEntity.php
@@ -52,6 +52,7 @@ use Drupal\Core\DependencyInjection\DependencySerializationTrait;
  *     "active",
  *     "do_replacement",
  *     "custom_404",
+ *     "allow_empty_variable",
  *   },
  *   links = {
  *     "edit-form" = "/admin/config/archipelago/fragariaredirect/{fragariaredirect_entity}/edit",
@@ -130,6 +131,14 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
    * @var bool
    */
   public bool $variable_path_suffix = FALSE;
+
+  /**
+   * If this Route can serve requests without the {key} part.
+   *  Only Applies for the unsuffixed versions of the route.
+   *
+   * @var bool
+   */
+  public bool $allow_empty_variable = FALSE;
 
   /**
    * The Search API Index ID of the field.
@@ -368,6 +377,14 @@ class FragariaRedirectConfigEntity extends ConfigEntityBase implements FragariaC
 
   public function getCustom404(): ?string {
     return $this->custom_404;
+  }
+
+  public function getAllowEmptyVariable(): bool {
+    return $this->allow_empty_variable;
+  }
+
+  public function setAllowEmptyVariable(bool $allow_empty_variable): void {
+    $this->allow_empty_variable = $allow_empty_variable;
   }
 
 }

--- a/src/Form/FragariaDataCiteConfigForm.php
+++ b/src/Form/FragariaDataCiteConfigForm.php
@@ -249,10 +249,10 @@ class FragariaDataCiteConfigForm extends ConfigFormBase {
 
     if ($form_state->getValue('repository_fabrica_user') && $form_state->getValue('repository_fabrica_password')) {
       $config->set(
-        'repository_fabrica_user_test', trim($form_state->getValue('repository_fabrica_user') ?? ' ')
+        'repository_fabrica_user', trim($form_state->getValue('repository_fabrica_user') ?? ' ')
       )
         ->set(
-          'repository_fabrica_password_test', trim($form_state->getValue('repository_fabrica_password') ?? ' ')
+          'repository_fabrica_password', trim($form_state->getValue('repository_fabrica_password') ?? ' ')
         );
     }
 

--- a/src/Form/FragariaRedirectConfigEntityForm.php
+++ b/src/Form/FragariaRedirectConfigEntityForm.php
@@ -14,7 +14,7 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity;
 
 /**
- * Form handler for metadataexpose_entity config entity add and edit.
+ * Form handler for Fragaria Redirect config entity add and edit.
  */
 class FragariaRedirectConfigEntityForm extends EntityForm {
 
@@ -23,11 +23,11 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
    */
   private StrawberryfieldUtilityService $strawberryfieldUtility;
 
-
   /**
    * FragariaRedirectConfigEntityForm constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\strawberryfield\StrawberryfieldUtilityService $strawberryfield_utility_service
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
@@ -90,7 +90,8 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
           $field_options[$key] = $field['label'];
         }
     }
-
+    $prefixes = !$fragariaredirect_config->isNew() ? $fragariaredirect_config->getPathPrefixes() : NULL;
+    $prefixes = is_array($prefixes) ? implode(PHP_EOL, $prefixes ?? '') : $prefixes;
     $form = [
       'label' => [
         '#id' => 'label',
@@ -113,21 +114,22 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
       'do_replacement' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Enable this if you removed your do/{uuid} path aliases but still (or finally) believe having REAL PURLs is important.'),
-        '#Description' => $this->t('This will disable suffixes, search api field matching and the Variable part will become the UUID of the node'),
+        '#description' => $this->t('This will disable suffixes, search api field matching and the Variable part will become the UUID of the node. You still need to define at least one PREFIX'),
         '#required' => FALSE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->isDoReplacement() : FALSE,
       ],
-      'path_prefix' => [
-        '#type' => 'textfield',
-        '#title' => $this->t('The Prefix (that follows your domain) for the Redirect Route.'),
+      'path_prefixes' => [
+        '#type' => 'textarea',
+        '#title' => $this->t('The Prefixes (that immediately follow after your domain name) for the Redirect Route.'),
+        '#description' => $this->t('Enter one per line. Danger: using built in route prefixes (e.g node, admin, ajax) might break your site. Be careful!'),
         '#required' => TRUE,
-        '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->getPathPrefix() : NULL,
+        '#default_value' => $prefixes,
       ],
       'path_suffixes_element' => [
         '#type' => 'textarea',
         '#title' => $this->t('The Suffixes (that follow the prefix + the variable part) for the Redirect Route.'),
         '#required' => FALSE,
-        '#default_value' => (!$fragariaredirect_config->isNew()) ? implode("\n", $fragariaredirect_config->getPathSuffixes()): NULL,
+        '#default_value' => (!$fragariaredirect_config->isNew()) ? implode(PHP_EOL, $fragariaredirect_config->getPathSuffixes()): NULL,
         '#description' => $this->t('Enter one by line. This configuration option is not required.'),
       ],
       'variable_path_suffix' => [
@@ -167,15 +169,27 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
         '#type' => 'textarea',
         '#title' => $this->t('Add static prefixes for to the variable part/argument of the path. '),
         '#required' => FALSE,
-        '#default_value' => (!$fragariaredirect_config->isNew()) ? implode("\n", $fragariaredirect_config->getSearchApiFieldValuePrefixes()): NULL,
+        '#default_value' => (!$fragariaredirect_config->isNew()) ? implode(PHP_EOL, $fragariaredirect_config->getSearchApiFieldValuePrefixes()): NULL,
         '#description' => $this->t('Enter one by line. This is useful when the variable part of the ROUTE does not match 1:1 the actual indexed data. e.g the route is /oldrepo/1 and the indexed value is "namespace:1". In that case add "namespace:" here.'),
       ],
       'search_api_field_value_suffixes_element' => [
         '#type' => 'textarea',
         '#title' => $this->t('Add static suffixes for to the variable part/argument of the path. '),
         '#required' => FALSE,
-        '#default_value' => (!$fragariaredirect_config->isNew()) ? implode("\n", $fragariaredirect_config->getSearchApiFieldValueSuffixes()): NULL,
+        '#default_value' => (!$fragariaredirect_config->isNew()) ? implode(PHP_EOL, $fragariaredirect_config->getSearchApiFieldValueSuffixes()): NULL,
         '#description' => $this->t('Enter one by line. This is useful when the variable part of the ROUTE does not match 1:1 the actual indexed data. e.g the route is /oldrepo/namespace:1 and the indexed value is "namespace:1-page". In that case add "-page" here.'),
+      ],
+      'segments_in_pattern' => [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('What parts of the matched URL should be sent to the search API to match against the field'),
+        '#description' => $this->t('Check all that apply. At least one needs to be enabled, by default the "variable" part is enabled and we recommend to keep it so.'),
+        '#options' => [
+          'prefixes' => 'static prefix(es)',
+          'variable' => 'variable (including variable suffix(es) if any)',
+          'suffixes' => 'static or catch all suffix(es)',
+        ],
+        '#required' => TRUE,
+        '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->getSegmentsInPattern(): ['variable'],
       ],
       'redirect_http_code' => [
         '#type' => 'select',
@@ -202,16 +216,20 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     // Remove button and internal Form API values from submitted values.
     $form_state->cleanValues();
     $suffixes = $form_state->getValue('path_suffixes_element','');
-    $suffixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode("\n", $suffixes));
+    $suffixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode(PHP_EOL, $suffixes));
     $suffixes = array_filter($suffixes);
+
+    $prefixes = $form_state->getValue('path_prefixes','');
+    $prefixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode(PHP_EOL, $prefixes));
+    $prefixes = array_filter($prefixes);
 
 
     $search_api_field_value_prefixes = $form_state->getValue('search_api_field_value_prefixes_element','');
-    $search_api_field_value_prefixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode("\n", $search_api_field_value_prefixes));
+    $search_api_field_value_prefixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode(PHP_EOL, $search_api_field_value_prefixes));
     $search_api_field_value_prefixes = array_filter($search_api_field_value_prefixes);
 
     $search_api_field_value_suffixes = $form_state->getValue('search_api_field_value_suffixes_element','');
-    $search_api_field_value_suffixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode("\n", $search_api_field_value_suffixes));
+    $search_api_field_value_suffixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode(PHP_EOL, $search_api_field_value_suffixes));
     $search_api_field_value_suffixes = array_filter($search_api_field_value_suffixes);
     if ($form_state->getValue('do_replacement')) {
       $search_api_field_value_suffixes = [];
@@ -220,6 +238,7 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     }
 
     $this->entity = $this->buildEntity($form, $form_state);
+    $this->entity->setPathSuffixes($prefixes);
     $this->entity->setDoReplacement($form_state->getValue('do_replacement') ? TRUE : FALSE);
     $this->entity->setPathSuffixes(is_array($suffixes) ? $suffixes : []);
     $this->entity->setSearchApiFieldValueSuffixes(is_array($search_api_field_value_suffixes) ? $search_api_field_value_suffixes : []);

--- a/src/Form/FragariaRedirectConfigEntityForm.php
+++ b/src/Form/FragariaRedirectConfigEntityForm.php
@@ -8,6 +8,9 @@ use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Core\Routing\RequestContext;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\strawberryfield\StrawberryfieldUtilityService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
@@ -24,6 +27,21 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
   private StrawberryfieldUtilityService $strawberryfieldUtility;
 
   /**
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  private PathValidatorInterface $pathValidator;
+
+  /**
+   * @var \Drupal\Core\Routing\RequestContext
+   */
+  private RequestContext $requestContext;
+
+  /**
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  private AliasManagerInterface $aliasManager;
+
+  /**
    * FragariaRedirectConfigEntityForm constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -31,10 +49,16 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
-    StrawberryfieldUtilityService $strawberryfield_utility_service
+    StrawberryfieldUtilityService $strawberryfield_utility_service,
+    PathValidatorInterface $path_validator,
+    RequestContext $request_context,
+    AliasManagerInterface $alias_manager
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->strawberryfieldUtility = $strawberryfield_utility_service;
+    $this->pathValidator = $path_validator;
+    $this->requestContext = $request_context;
+    $this->aliasManager = $alias_manager;
   }
 
   /**
@@ -44,6 +68,9 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('strawberryfield.utility'),
+      $container->get('path.validator'),
+      $container->get('router.request_context'),
+      $container->get('path_alias.manager'),
     );
   }
 
@@ -167,17 +194,17 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
       ],
       'search_api_field_value_prefixes_element' => [
         '#type' => 'textarea',
-        '#title' => $this->t('Add static prefixes for to the variable part/argument of the path. '),
+        '#title' => $this->t('Add static prefixes for to the variable part/argument of the path just before matching against the index.'),
         '#required' => FALSE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? implode(PHP_EOL, $fragariaredirect_config->getSearchApiFieldValuePrefixes()): NULL,
-        '#description' => $this->t('Enter one by line. This is useful when the variable part of the ROUTE does not match 1:1 the actual indexed data. e.g the route is /oldrepo/1 and the indexed value is "namespace:1". In that case add "namespace:" here.'),
+        '#description' => $this->t('Not part of the PATH. Enter one by line. This is useful when the variable part of the ROUTE does not match 1:1 the actual indexed data. e.g the route is /oldrepo/1 and the indexed value is "namespace:1". In that case add "namespace:" here.'),
       ],
       'search_api_field_value_suffixes_element' => [
         '#type' => 'textarea',
-        '#title' => $this->t('Add static suffixes for to the variable part/argument of the path. '),
+        '#title' => $this->t('Add static suffixes for to the variable part/argument of the path just before matching against the index.'),
         '#required' => FALSE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? implode(PHP_EOL, $fragariaredirect_config->getSearchApiFieldValueSuffixes()): NULL,
-        '#description' => $this->t('Enter one by line. This is useful when the variable part of the ROUTE does not match 1:1 the actual indexed data. e.g the route is /oldrepo/namespace:1 and the indexed value is "namespace:1-page". In that case add "-page" here.'),
+        '#description' => $this->t('Not part of the PATH. Enter one by line. This is useful when the variable part of the ROUTE does not match 1:1 the actual indexed data. e.g the route is /oldrepo/namespace:1 and the indexed value is "namespace:1-page". In that case add "-page" here.'),
       ],
       'segments_in_pattern' => [
         '#type' => 'checkboxes',
@@ -201,6 +228,13 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
         '#required' => TRUE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->getRedirectHttpCode(): NULL,
       ],
+      'custom_404' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('A relative path to be used on not found/404 page.'),
+        '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->getCustom404(): NULL,
+        '#required' => FALSE,
+        '#field_prefix' => $this->requestContext->getCompleteBaseUrl(),
+      ],
       'active' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Is this Fragaria Redirect Route active?'),
@@ -210,6 +244,20 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     ];
 
     return $form;
+  }
+
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    //Validate Custom 404 page.
+    if (!$form_state->isValueEmpty('custom_404')) {
+      $form_state->setValueForElement($form['custom_404'], $this->aliasManager->getPathByAlias($form_state->getValue('custom_404')));
+    }
+    if (($value = $form_state->getValue('custom_404')) && $value[0] !== '/') {
+      $form_state->setErrorByName('custom_404', $this->t("The path '%path' has to start with a slash.", ['%path' => $form_state->getValue('custom_404')]));
+    }
+    if (!$form_state->isValueEmpty('custom_404') && !$this->pathValidator->isValid($form_state->getValue('custom_404'))) {
+      $form_state->setErrorByName('custom_404', $this->t("Either the path '%path' is invalid or you do not have access to it.", ['%path' => $form_state->getValue('custom_404')]));
+    }
+    parent::validateForm($form, $form_state);
   }
 
   public function submitForm(array &$form, FormStateInterface $form_state) {

--- a/src/Form/FragariaRedirectConfigEntityForm.php
+++ b/src/Form/FragariaRedirectConfigEntityForm.php
@@ -151,6 +151,7 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
         '#description' => $this->t('Enter one per line. Danger: using built in route prefixes (e.g node, admin, ajax) might break your site. Be careful!'),
         '#required' => TRUE,
         '#default_value' => $prefixes,
+        '#resizable' => 'vertical',
       ],
       'path_suffixes_element' => [
         '#type' => 'textarea',
@@ -158,10 +159,11 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
         '#required' => FALSE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? implode(PHP_EOL, $fragariaredirect_config->getPathSuffixes()): NULL,
         '#description' => $this->t('Enter one by line. This configuration option is not required.'),
-      ],
+        '#resizable' => 'vertical',
+        ],
       'variable_path_suffix' => [
         '#type' => 'checkbox',
-        '#title' => $this->t('Instead of fixed Prefixes add a single {catch_all} variable suffix at the end'),
+        '#title' => $this->t('Instead of fixed Suffixes, this adds a single {catch_all} variable suffix at the end'),
         '#required' => FALSE,
         '#return_value' => TRUE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->getVariablePathSuffix(): FALSE,
@@ -235,6 +237,12 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
         '#required' => FALSE,
         '#field_prefix' => $this->requestContext->getCompleteBaseUrl(),
       ],
+      'allow_empty_variable' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('If this route can also serve (for the un-suffixed version) requests without the {variable} part.'),
+        '#return_value' => TRUE,
+        '#default_value' => ($fragariaredirect_config->isNew()) ? TRUE : (bool) $fragariaredirect_config->getAllowEmptyVariable()
+      ],
       'active' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Is this Fragaria Redirect Route active?'),
@@ -288,6 +296,7 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     $this->entity = $this->buildEntity($form, $form_state);
     $this->entity->setPathPrefixes($prefixes);
     $this->entity->setDoReplacement($form_state->getValue('do_replacement') ? TRUE : FALSE);
+    $this->entity->setAllowEmptyVariable($form_state->getValue('allow_empty_variable') ? TRUE : FALSE);
     $this->entity->setPathSuffixes(is_array($suffixes) ? $suffixes : []);
     $this->entity->setSearchApiFieldValueSuffixes(is_array($search_api_field_value_suffixes) ? $search_api_field_value_suffixes : []);
     $this->entity->setSearchApiFieldValuePrefixes(is_array($search_api_field_value_prefixes) ? $search_api_field_value_prefixes : []);

--- a/src/Form/FragariaRedirectConfigEntityForm.php
+++ b/src/Form/FragariaRedirectConfigEntityForm.php
@@ -145,7 +145,7 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
         '#required' => FALSE,
         '#default_value' => (!$fragariaredirect_config->isNew()) ? $fragariaredirect_config->isDoReplacement() : FALSE,
       ],
-      'path_prefixes' => [
+      'path_prefixes_element' => [
         '#type' => 'textarea',
         '#title' => $this->t('The Prefixes (that immediately follow after your domain name) for the Redirect Route.'),
         '#description' => $this->t('Enter one per line. Danger: using built in route prefixes (e.g node, admin, ajax) might break your site. Be careful!'),
@@ -267,7 +267,7 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     $suffixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode(PHP_EOL, $suffixes));
     $suffixes = array_filter($suffixes);
 
-    $prefixes = $form_state->getValue('path_prefixes','');
+    $prefixes = $form_state->getValue('path_prefixes_element','');
     $prefixes = array_map(function ($line) { return $line ? trim($line) : NULL;}, explode(PHP_EOL, $prefixes));
     $prefixes = array_filter($prefixes);
 
@@ -286,7 +286,7 @@ class FragariaRedirectConfigEntityForm extends EntityForm {
     }
 
     $this->entity = $this->buildEntity($form, $form_state);
-    $this->entity->setPathSuffixes($prefixes);
+    $this->entity->setPathPrefixes($prefixes);
     $this->entity->setDoReplacement($form_state->getValue('do_replacement') ? TRUE : FALSE);
     $this->entity->setPathSuffixes(is_array($suffixes) ? $suffixes : []);
     $this->entity->setSearchApiFieldValueSuffixes(is_array($search_api_field_value_suffixes) ? $search_api_field_value_suffixes : []);

--- a/src/Routing/FragariaRedirectRoutingService.php
+++ b/src/Routing/FragariaRedirectRoutingService.php
@@ -24,8 +24,7 @@ class FragariaRedirectRoutingService {
   /**
    * FragariaRedirectRoutingService constructor.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface      $entity_type_manager
-   * @param \Drupal\Core\Config\ConfigFactoryInterface          $config_factory
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    */
 
   public function __construct(
@@ -65,70 +64,84 @@ class FragariaRedirectRoutingService {
     /* @TODO
      * - sanitize prefix, suffixes
      * - check if we can use the prefixed one as base route for the other
-    */
+     */
     foreach ($entities as $entity) {
       if ($entity->isActive()) {
-        $prefix = $entity->getPathPrefix();
-        $prefix = trim(trim($prefix), '/');
+        $prefixes = $entity->getPathPrefixes();
+        $prefixes = array_map(function($prefix) { if (is_string($prefix)) { return trim(trim($prefix), '/');} else {return NULL;}}, $prefixes);
+        $prefixes = array_filter($prefixes);
+        $fragaria_routes = new \WeakMap();
         if ($entity->isDoReplacement()) {
-          $route = new Route(
-            '/' . $prefix . '/{key}',
-            [
-              '_controller' => 'Drupal\fragaria\Controller\Redirect::redirect_do',
-            ],
-            [
-              '_access' => 'TRUE',
-            ]
-          );
-          $route->setRequirement('key', "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
-          $options['parameters']['key'] = ['type' => 'entity:node'];
-          $options['parameters']['resource_type'] = ['type' => 'ado'];
-          $route->setOptions($options);
-          $route->setDefault('fragariaredirect_entity', $entity->id());
-          $route_collection->add('fragaria_redirect.' . $entity->id(), $route);
+          foreach ($prefixes as $prefix) {
+            $route = new Route(
+              '/' . $prefix . '/{key}',
+              [
+                '_controller' => 'Drupal\fragaria\Controller\Redirect::redirect_do',
+              ],
+              [
+                '_access' => 'TRUE',
+              ]
+            );
+            $route->setRequirement('key', "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+            $options['parameters']['key'] = ['type' => 'entity:node'];
+            $options['parameters']['resource_type'] = ['type' => 'ado'];
+            $route->setOptions($options);
+            $route->setDefault('fragariaredirect_entity', $entity->id());
+            $fragaria_routes[$route] = TRUE;
+            $name = 'fragaria_redirect.' . md5($prefix) .'-'. $entity->id();
+            $route_collection->add($name, $route);
+          }
         }
         else {
-          $route = new Route(
-            '/' . $prefix . '/{key}',
-            [
-              '_controller' => 'Drupal\fragaria\Controller\Redirect::redirect_processor',
-            ],
-            [
-              '_access' => 'TRUE',
-            ]
-          );
-          $route->setDefault('fragariaredirect_entity', $entity->id());
-          $route_collection->add('fragaria_redirect.' . $entity->id(), $route);
+          foreach ($prefixes as $prefix) {
+            $route = new Route(
+              '/' . $prefix . '/{key}',
+              [
+                '_controller' => 'Drupal\fragaria\Controller\Redirect::redirect_processor',
+              ],
+              [
+                '_access' => 'TRUE',
+              ]
+            );
+            $name = 'fragaria_redirect.' . md5($prefix) .'-'. $entity->id();
+            $route->setDefault('fragariaredirect_entity', $entity->id());
+            $fragaria_routes[$route] = $name;
+            $route_collection->add($name, $route);
+          }
         }
         if (!$entity->isDoReplacement()) {
           if ($entity->getVariablePathSuffix()) {
-            $route_variable = clone $route;
-            $route_variable->setPath(
-              $route_variable->getPath() . '/{catch_all}'
-            );
-            $route_variable->setOption(
-              '_controller',
-              'Drupal\fragaria\Controller\Redirect::redirect_processor_variable'
-            );
-            $route_variable->setDefault('catch_all', '');
-            $route_collection->add(
-              'fragaria_redirect.' . $entity->id() . '.variable',
-              $route_variable
-            );
-
+            foreach ($fragaria_routes as $local_route => $name) {
+              $route_variable = clone $local_route;
+              $route_variable->setPath(
+                $route_variable->getPath() . '/{catch_all}'
+              );
+              $route_variable->setOption(
+                '_controller',
+                'Drupal\fragaria\Controller\Redirect::redirect_processor_variable'
+              );
+              $route_variable->setDefault('catch_all', '');
+              $route_collection->add(
+                $name. '.variable',
+                $route_variable
+              );
+            }
           }
           else {
             $suffixes = $entity->getPathSuffixes();
             foreach ($suffixes as $key => $suffix) {
-              $suffix = trim(trim($suffix), '/');
-              $route_suffix = clone $route;
-              $route_suffix->setPath($route_suffix->getPath() . '/' . $suffix);
-              $route_collection->add(
-                'fragaria_redirect.' . $entity->id() . '.' . $key, $route_suffix
-              );
+              foreach ($fragaria_routes as $local_route => $name) {
+                $suffix = trim(trim($suffix), '/');
+                $route_suffix = clone $local_route;
+                $route_suffix->setPath($route_suffix->getPath() . '/' . $suffix);
+                $route_collection->add(
+                  $name . '.' . $key, $route_suffix
+                );
+              }
             }
           }
         }
+        unset($fragaria_routes);
       }
     }
     return $route_collection;

--- a/src/Routing/FragariaRedirectRoutingService.php
+++ b/src/Routing/FragariaRedirectRoutingService.php
@@ -103,6 +103,9 @@ class FragariaRedirectRoutingService {
             );
             $name = 'fragaria_redirect.' . md5($prefix) .'-'. $entity->id();
             $route->setDefault('fragariaredirect_entity', $entity->id());
+            if ($entity->getAllowEmptyVariable()) {
+              $route->setDefault('key', '');
+            }
             $fragaria_routes[$route] = $name;
             $route_collection->add($name, $route);
           }
@@ -119,6 +122,8 @@ class FragariaRedirectRoutingService {
                 'Drupal\fragaria\Controller\Redirect::redirect_processor_variable'
               );
               $route_variable->setDefault('catch_all', '');
+              // Because of the catch call {key} can't have a default
+              $route_variable->setDefault('key', NULL);
               $route_collection->add(
                 $name. '.variable',
                 $route_variable
@@ -132,6 +137,8 @@ class FragariaRedirectRoutingService {
                 $suffix = trim(trim($suffix), '/');
                 $route_suffix = clone $local_route;
                 $route_suffix->setPath($route_suffix->getPath() . '/' . $suffix);
+                // Because of the Fixed Suffix {key} can't also have a default
+                $route_suffix->setDefault('key', NULL);
                 $route_collection->add(
                   $name . '.' . $key, $route_suffix
                 );

--- a/src/Routing/FragariaRedirectRoutingService.php
+++ b/src/Routing/FragariaRedirectRoutingService.php
@@ -68,8 +68,6 @@ class FragariaRedirectRoutingService {
     foreach ($entities as $entity) {
       if ($entity->isActive()) {
         $prefixes = $entity->getPathPrefixes();
-        $prefixes = array_map(function($prefix) { if (is_string($prefix)) { return trim(trim($prefix), '/');} else {return NULL;}}, $prefixes);
-        $prefixes = array_filter($prefixes);
         $fragaria_routes = new \WeakMap();
         if ($entity->isDoReplacement()) {
           foreach ($prefixes as $prefix) {


### PR DESCRIPTION
# What?

see #16 

Some TODOs:
- Prefixes can not overlap. e.g `/hola` and `/hola/chao` will clash. either `/hola/chao` and `/hola/goodbye` or just`/hola`. All this needs to be validated and it is a bit hard. I need to split by "/", and generate a tree.... 

- I need to "reprocess" the matched URL agains the chosen segments for the new  "what should match/segment" picker. In old time that was not needed at all